### PR TITLE
Update to use `lru-cache` as juicer cache storage.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,3 +11,8 @@ Juicer Express Adapter Change History
 -----
 
 * Update dependencies in package.json after juicer released 0.6.12.
+
+0.1.8
+-----
+
+* Update to use `lru-cache` as juicer cache storage.

--- a/index.js
+++ b/index.js
@@ -1,11 +1,20 @@
 var juicer = require('juicer');
 var fs = require('fs');
 var path = require('path');
+var crypto = require('crypto');
 var LRUCache = require('lru-cache');
 var cache = LRUCache({
     max: 1000,
     maxAge: 1000 * 60 * 60 * 24
 });
+
+var _set = cache.set;
+
+cache.set = function(key, value, maxAge) {
+    key = crypto.createHash('md5').update(key).digest('hex');
+    _set.call(cache, key, value, maxAge);
+    console.log(key, value, maxAge);
+};
 
 // disabled auto strip
 juicer.set('strip', false);

--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
 var juicer = require('juicer');
 var fs = require('fs');
 var path = require('path');
+var LRUCache = require('lru-cache');
+var cache = LRUCache({
+    max: 1000,
+    maxAge: 1000 * 60 * 60 * 24
+});
 
 // disabled auto strip
 juicer.set('strip', false);
+juicer.set('cachestore', cache);
 
 module.exports = function(tplPath, options, fn) {
     var deep = function(data, scope, _tmp) {
@@ -62,8 +68,6 @@ module.exports = function(tplPath, options, fn) {
 
     fs.readFile(tplPath, 'utf8', function(err, str) {
         if (err) return fn(err);
-        // PreDetect For Helper Register
-        includeFileDetect(tplPath, str, { cache: false });
         str = juicer(str, options);
         str = includeFileDetect(tplPath, str);
         fn(null, str);

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var cache = LRUCache({
 
 // disabled auto strip
 juicer.set('strip', false);
+juicer.set('cache', true);
 juicer.set('cachestore', cache);
 
 module.exports = function(tplPath, options, fn) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juicer-express-adapter",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "a high-performance lightweight javascript template engine",
   "homepage": "http://juicer.name",
   "author": "juicer.js authors {badkaikai@gmail.com | http://benben.cc}",
@@ -21,6 +21,7 @@
     "node": ">=0.4.7"
   },
   "dependencies": {
-    "juicer": "^0.6.12"
+    "juicer": "^0.6.13",
+    "lru-cache": "^4.0.0"
   }
 }


### PR DESCRIPTION
Update to use `lru-cache` as juicer cache storage.
